### PR TITLE
Pin pip to a specific version

### DIFF
--- a/setup-pip-tools/action.yml
+++ b/setup-pip-tools/action.yml
@@ -1,4 +1,4 @@
-name: "Run pip-compile"
+name: "Set up pip-tools"
 description: "Install pip-tools and run pip-compile on a set of requirements files."
 inputs:
   pip-tools-version:
@@ -24,7 +24,9 @@ runs:
         shell: bash
 
       - name: Install pip-tools
+        # The latest version of pip and pip-tools creates absolute paths instead of relative paths
+        # when compiling requirements files.
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip==24.3
           pip install ${{ steps.get-pip-tools-version-suffix.outputs.PIP_TOOLS_VERSION }}
         shell: bash

--- a/setup-pip-tools/action.yml
+++ b/setup-pip-tools/action.yml
@@ -27,6 +27,6 @@ runs:
         # The latest version of pip and pip-tools creates absolute paths instead of relative paths
         # when compiling requirements files.
         run: |
-          pip install --upgrade pip==24.3
+          pip install --upgrade pip==24.2
           pip install ${{ steps.get-pip-tools-version-suffix.outputs.PIP_TOOLS_VERSION }}
         shell: bash


### PR DESCRIPTION
The latest version of pip and pip-tools creates absolute paths instead of relative paths when compiling requirements files. Pin pip to version 24.3, which should keep the relative paths.